### PR TITLE
Fix variable M not declared as local in startup.lua causing problems with dump in Lua 5.1

### DIFF
--- a/examples/startup.lua
+++ b/examples/startup.lua
@@ -2,7 +2,7 @@
 
 -- this file is public domain
 
-M = {}
+local M = {}
 
 -- Return a recursive dump table (or iterator) `tbl`, with indentation
 --   Return as both a string (first) and a table of lines (second).

--- a/rockspecs/lua-yottadb-3.0-1.rockspec
+++ b/rockspecs/lua-yottadb-3.0-1.rockspec
@@ -1,0 +1,41 @@
+rockspec_format = "3.0"
+package = 'lua-yottadb'
+version = '3.0-1'
+source = {
+   url = 'git://github.com/anet-be/lua-yottadb.git',
+   tag = 'v' .. version:match('%d+.%d+'),
+}
+description = {
+   summary = 'lua-yottadb is a Lua language plugin for the MUMPS database.',
+
+	detailed = [[
+         lua-yottadb provides a shared library that lets the Lua language access 
+         a YottaDB database and the means to invoke M routines from within Lua.
+         While this project is stand-alone, there is a closely related project called 
+         MLua that goes in the other direction, allowing M software to invoke the Lua language. 
+         If you wish for both abilities, start with MLua which is designed to incorporate lua-yottadb.
+      ]],
+   homepage = 'https://github.com/anet-be/lua-yottadb',
+   license = 'AGPL',
+}
+
+test = {
+   type = 'command',
+   command = 'make test',
+}
+
+build = {
+   type = 'make',
+   build_target = 'all',
+   install_target = 'install',
+   variables = {
+      LUAROCKS_CFLAGS='$(CFLAGS)',  -- only necessary to get rid of a luarocks warning
+      LUAROCKS_PREFIX='$(PREFIX)',  -- let Makefile know where Lua wants it installed so it can detect --local flag
+      -- Don't set PREFIX='$(PREFIX)' because lua-yottadb needs its binaries to be in the system's Lua path. I don't really understand why luarocks sets its PREFIX to non-path locations
+   },
+   copy_directories = {'tests', 'examples', 'docs'},
+}
+dependencies = {
+   'lua >= 5.1',
+   -- If you depend on other rocks, add them here
+}


### PR DESCRIPTION
This update include two items:
- Fix a variable that should have been declared as local.
- Also add rockspec for version 3.0 that should have been added earlier when that was released.

**Problem**
If the user redefined global M in lua 5.1 then it would clobber the print() function's use of it to print a dump of tables.

**Reproduce this way**

To reproduce this:
* start lua with examples/startup.lua
* M = 'abcdefg'
print({x=5})
